### PR TITLE
Propagate all feature flags to Beat receivers

### DIFF
--- a/changelog/fragments/1783638976-propagate-all-feature-flags-to-beat-receivers.yaml
+++ b/changelog/fragments/1783638976-propagate-all-feature-flags-to-beat-receivers.yaml
@@ -1,0 +1,27 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Propagate all `agent.features` flags to Beat receivers
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: elastic-agent
+
+# PR URL; optional; the PR number that added the changeset.
+# pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+issue: https://github.com/elastic/elastic-agent/issues/15437

--- a/internal/pkg/otel/translate/otelconfig.go
+++ b/internal/pkg/otel/translate/otelconfig.go
@@ -75,12 +75,8 @@ func GetOtelConfig(
 	otelConfig := confmap.New()     // base config, nothing here for now
 	extensions := map[string]bool{} // we have to manually handle extensions because otel does not merge lists, it overrides them. This is a known issue: see https://github.com/open-telemetry/opentelemetry-collector/issues/8754
 
-	// Evaluate the FQDN feature flag once, so every component in this render sees a consistent
-	// value even if the global flag changes (via a concurrent policy update) while we iterate.
-	fqdnEnabled := features.FQDN()
-
 	for _, comp := range components {
-		componentConfig, compErr := getCollectorConfigForComponent(comp, info, fqdnEnabled, logger)
+		componentConfig, compErr := getCollectorConfigForComponent(comp, info, logger)
 		if compErr != nil {
 			return nil, compErr
 		}
@@ -159,7 +155,7 @@ func VerifyComponentIsOtelSupported(comp *component.Component) error {
 
 	// check if the actual configuration is supported. We need to actually generate the config and look for
 	// the right kind of error
-	_, compErr := getCollectorConfigForComponent(comp, &info.AgentInfo{}, features.FQDN(), logp.NewNopLogger())
+	_, compErr := getCollectorConfigForComponent(comp, &info.AgentInfo{}, logp.NewNopLogger())
 	if errors.Is(compErr, errors.ErrUnsupported) {
 		return fmt.Errorf("unsupported configuration for %s: %w", comp.ID, compErr)
 	}
@@ -257,7 +253,6 @@ func getKafkaPartitionerExtensionID(outputName string) otelcomponent.ID {
 func getCollectorConfigForComponent(
 	comp *component.Component,
 	info info.Agent,
-	fqdnEnabled bool,
 	logger *logp.Logger,
 ) (*confmap.Conf, error) {
 	exporterType, err := OutputTypeToExporterType(comp.OutputType)
@@ -269,7 +264,7 @@ func getCollectorConfigForComponent(
 	if err != nil {
 		return nil, err
 	}
-	receiversConfig, err := getReceiversConfigForComponent(comp, info, fqdnEnabled, outputQueueConfig)
+	receiversConfig, err := getReceiversConfigForComponent(comp, info, outputQueueConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -371,7 +366,6 @@ func getCollectorConfigForComponent(
 func getReceiversConfigForComponent(
 	comp *component.Component,
 	info info.Agent,
-	fqdnEnabled bool,
 	outputQueueConfig map[string]any,
 ) (map[string]any, error) {
 	receiverType, err := getReceiverTypeForComponent(comp)
@@ -446,11 +440,8 @@ func getReceiversConfigForComponent(
 	// indicate that beat receivers are managed by the elastic-agent
 	sharedConfig["management.otel.enabled"] = true
 
-	// propagate the FQDN feature flag into the receiver config
-	sharedConfig["features"] = map[string]any{
-		"fqdn": map[string]any{
-			"enabled": fqdnEnabled,
-		},
+	if receiverFeatures := beatReceiverFeatures(comp); len(receiverFeatures) > 0 {
+		sharedConfig["features"] = receiverFeatures
 	}
 
 	// When SingleReceiver is set, merge all stream inputs into one receiver keyed by
@@ -488,6 +479,21 @@ func getReceiversConfigForComponent(
 	}
 
 	return receiversConfig, nil
+}
+
+// beatReceiverFeatures unwraps agent.features from the component's feature
+// source into the top-level features block expected by Beats.
+func beatReceiverFeatures(comp *component.Component) map[string]any {
+	if comp.Features == nil || comp.Features.Source == nil {
+		return nil
+	}
+
+	agentConfig, ok := comp.Features.Source.AsMap()["agent"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	receiverFeatures, _ := agentConfig["features"].(map[string]any)
+	return receiverFeatures
 }
 
 // beatInputsKey returns the config key used to pass inputs/modules/monitors/protocols

--- a/internal/pkg/otel/translate/otelconfig_test.go
+++ b/internal/pkg/otel/translate/otelconfig_test.go
@@ -569,11 +569,6 @@ func TestGetOtelConfig(t *testing.T) {
 				"enabled": false,
 			},
 			"management.otel.enabled": true,
-			"features": map[string]any{
-				"fqdn": map[string]any{
-					"enabled": false,
-				},
-			},
 		}
 	}
 
@@ -740,11 +735,6 @@ func TestGetOtelConfig(t *testing.T) {
 				"enabled": false,
 			},
 			"management.otel.enabled": true,
-			"features": map[string]any{
-				"fqdn": map[string]any{
-					"enabled": false,
-				},
-			},
 		}
 	}
 
@@ -794,11 +784,6 @@ func TestGetOtelConfig(t *testing.T) {
 			"enabled": false,
 		},
 		"management.otel.enabled": true,
-		"features": map[string]any{
-			"fqdn": map[string]any{
-				"enabled": false,
-			},
-		},
 	}
 
 	tests := []struct {
@@ -1101,11 +1086,6 @@ func TestGetOtelConfig(t *testing.T) {
 							"enabled": false,
 						},
 						"management.otel.enabled": true,
-						"features": map[string]any{
-							"fqdn": map[string]any{
-								"enabled": false,
-							},
-						},
 					},
 				},
 				"service": map[string]any{
@@ -1667,11 +1647,6 @@ func TestGetOtelConfig(t *testing.T) {
 							"enabled": false,
 						},
 						"management.otel.enabled": true,
-						"features": map[string]any{
-							"fqdn": map[string]any{
-								"enabled": false,
-							},
-						},
 					},
 				},
 				"service": map[string]any{
@@ -1866,11 +1841,6 @@ func TestGetOtelConfig(t *testing.T) {
 							"enabled": false,
 						},
 						"management.otel.enabled": true,
-						"features": map[string]any{
-							"fqdn": map[string]any{
-								"enabled": false,
-							},
-						},
 					},
 				},
 				"service": map[string]any{
@@ -1982,11 +1952,6 @@ func TestGetOtelConfig(t *testing.T) {
 							"enabled": false,
 						},
 						"management.otel.enabled": true,
-						"features": map[string]any{
-							"fqdn": map[string]any{
-								"enabled": false,
-							},
-						},
 					},
 				},
 				"service": map[string]any{
@@ -2719,7 +2684,6 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 			result, err := getReceiversConfigForComponent(
 				tt.component,
 				testAgentInfo,
-				false,
 				tt.outputQueueConfig,
 			)
 
@@ -2773,11 +2737,11 @@ func TestGetReceiversConfigForComponent(t *testing.T) {
 	}
 }
 
-// TestGetReceiversConfigForComponentFQDN verifies that the agent's FQDN feature flag is
-// propagated into the generated beat receiver config.
-func TestGetReceiversConfigForComponentFQDN(t *testing.T) {
+// TestGetReceiversConfigForComponentFeatures verifies that all agent feature flags
+// are propagated into the generated Beat receiver config.
+func TestGetReceiversConfigForComponentFeatures(t *testing.T) {
 	comp := &component.Component{
-		ID:        "filestream-fqdn",
+		ID:        "filestream-features",
 		InputType: "filestream",
 		InputSpec: &component.InputRuntimeSpec{
 			BinaryName: "elastic-otel-collector",
@@ -2811,31 +2775,85 @@ func TestGetReceiversConfigForComponentFQDN(t *testing.T) {
 		},
 	}
 
-	fqdnConfig := func(t *testing.T, enabled bool) map[string]any {
-		t.Helper()
+	featureFlags, err := features.Parse(map[string]any{
+		"agent": map[string]any{
+			"features": map[string]any{
+				"fqdn": map[string]any{
+					"enabled": false,
+				},
+				"log_input_run_as_filestream": map[string]any{
+					"enabled": true,
+				},
+				"aws_s3_v2": map[string]any{
+					"enabled": true,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	comp.Features = featureFlags.AsProto()
+	// The raw source is the only propagation path; the typed FQDN value must
+	// not override the value preserved in agent.features.
+	comp.Features.Fqdn.Enabled = true
 
-		result, err := getReceiversConfigForComponent(comp, &info.AgentInfo{}, enabled, nil)
-		require.NoError(t, err)
-		require.Len(t, result, 1)
+	result, err := getReceiversConfigForComponent(comp, &info.AgentInfo{}, nil)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
 
-		var receiverConfig map[string]any
-		for _, v := range result {
-			receiverConfig = v.(map[string]any)
-		}
-		featuresConfig, ok := receiverConfig["features"].(map[string]any)
-		require.True(t, ok, "features config should be present and a map")
-		return featuresConfig
+	var receiverConfig map[string]any
+	for _, value := range result {
+		receiverConfig = value.(map[string]any)
+	}
+	require.Equal(t, map[string]any{
+		"fqdn": map[string]any{
+			"enabled": false,
+		},
+		"log_input_run_as_filestream": map[string]any{
+			"enabled": true,
+		},
+		"aws_s3_v2": map[string]any{
+			"enabled": true,
+		},
+	}, receiverConfig["features"])
+	require.Equal(t, false, comp.Features.Source.AsMap()["agent"].(map[string]any)["features"].(map[string]any)["fqdn"].(map[string]any)["enabled"],
+		"building receiver config must not mutate the component feature source")
+}
+
+func TestGetReceiversConfigForComponentWithoutFeatures(t *testing.T) {
+	comp := &component.Component{
+		ID:        "filestream-no-features",
+		InputType: "filestream",
+		InputSpec: &component.InputRuntimeSpec{
+			BinaryName: "elastic-otel-collector",
+			Spec: component.InputSpec{
+				Name: "filestream",
+				Command: &component.CommandSpec{
+					Args: []string{"filebeat"},
+				},
+			},
+		},
+		Units: []component.Unit{
+			{
+				ID:   "filestream-unit",
+				Type: client.UnitTypeInput,
+				Config: component.MustExpectedConfig(map[string]any{
+					"streams": []any{
+						map[string]any{
+							"id":    "test-1",
+							"paths": []any{"/var/log/*.log"},
+						},
+					},
+				}),
+			},
+		},
 	}
 
-	t.Run("enabled", func(t *testing.T) {
-		featuresConfig := fqdnConfig(t, true)
-		assert.Equal(t, map[string]any{"fqdn": map[string]any{"enabled": true}}, featuresConfig)
-	})
-
-	t.Run("disabled", func(t *testing.T) {
-		featuresConfig := fqdnConfig(t, false)
-		assert.Equal(t, map[string]any{"fqdn": map[string]any{"enabled": false}}, featuresConfig)
-	})
+	result, err := getReceiversConfigForComponent(comp, &info.AgentInfo{}, nil)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	for _, value := range result {
+		require.NotContains(t, value.(map[string]any), "features")
+	}
 }
 
 func TestVerifyComponentIsOtelSupported(t *testing.T) {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -5,7 +5,6 @@
 package features
 
 import (
-	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -186,20 +185,31 @@ func (f *Flags) setEncryptedConfig(newValue bool) {
 	f.encryptedConfig = newValue
 }
 
-// setSource sets the source from he given cfg.
-func (f *Flags) setSource(c cfg) error {
-	// Use JSON marshalling-unmarshalling to convert cfg to mapstr
-	data, err := json.Marshal(c)
-	if err != nil {
-		return fmt.Errorf("could not convert feature flags configuration to JSON: %w", err)
+// setSource preserves the original agent.features subtree so consumers can
+// receive feature flags that are not represented by typed Agent fields.
+func (f *Flags) setSource(c *config.Config) error {
+	options := make([]interface{}, len(config.NoResolveOptions))
+	for i, option := range config.NoResolveOptions {
+		options[i] = option
 	}
 
-	var s map[string]interface{}
-	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("could not convert feature flags JSON to mapstr: %w", err)
+	var policy map[string]any
+	if err := c.UnpackTo(&policy, options...); err != nil {
+		return fmt.Errorf("could not unpack feature flags source: %w", err)
 	}
 
-	source, err := structpb.NewStruct(s)
+	featureConfig := map[string]any{}
+	if agentConfig, ok := policy["agent"].(map[string]any); ok {
+		if configuredFeatures, ok := agentConfig["features"].(map[string]any); ok {
+			featureConfig = configuredFeatures
+		}
+	}
+
+	source, err := structpb.NewStruct(map[string]any{
+		"agent": map[string]any{
+			"features": featureConfig,
+		},
+	})
 	if err != nil {
 		return fmt.Errorf("unable to create source from feature flags configuration: %w", err)
 	}
@@ -269,7 +279,7 @@ func Parse(policy any) (*Flags, error) {
 		flags.setEncryptedConfig(defaultEncryptedConfig)
 	}
 
-	if err := flags.setSource(parsedFlags); err != nil {
+	if err := flags.setSource(c); err != nil {
 		return nil, fmt.Errorf("error creating feature flags source: %w", err)
 	}
 

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -82,6 +82,49 @@ agent:
 	}
 }
 
+func TestParsePreservesFeatureSource(t *testing.T) {
+	c, err := config.NewConfigFrom(`
+agent:
+  features:
+    fqdn:
+      enabled: true
+    log_input_run_as_filestream:
+      enabled: false
+    aws_s3_v2:
+      enabled: true
+    future_feature:
+      enabled: true
+      settings:
+        mode: test
+`)
+	require.NoError(t, err)
+
+	flags, err := Parse(c)
+	require.NoError(t, err)
+	require.True(t, flags.FQDN())
+	require.Equal(t, map[string]any{
+		"agent": map[string]any{
+			"features": map[string]any{
+				"fqdn": map[string]any{
+					"enabled": true,
+				},
+				"log_input_run_as_filestream": map[string]any{
+					"enabled": false,
+				},
+				"aws_s3_v2": map[string]any{
+					"enabled": true,
+				},
+				"future_feature": map[string]any{
+					"enabled": true,
+					"settings": map[string]any{
+						"mode": "test",
+					},
+				},
+			},
+		},
+	}, flags.AsProto().Source.AsMap())
+}
+
 func TestFQDNCallbacks(t *testing.T) {
 	cb1Called, cb2Called := false, false
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Preserves the original `agent.features` subtree in component feature metadata and copies it into generated Beat receiver configs. Removes the separate global FQDN-only propagation path so feature source metadata is authoritative and future Beat-supported flags propagate without translator changes.

Adds coverage for FQDN, `log_input_run_as_filestream`, `aws_s3_v2`, unknown future flags, explicit false values, and missing feature metadata.

## Why is it important?

The OTel translator previously propagated only FQDN. Other Beat-supported feature flags were dropped, causing Beat receivers to behave differently from the Agent policy.

## Checklist

- [x] I have read and understood the [pull request guidelines](https://github.com/elastic/elastic-agent/blob/main/CONTRIBUTING.md#pull-request-guidelines) of this project.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- ~~[ ] I have added an integration test or an E2E test~~

Documentation, default configuration, and new integration coverage are not required; this fixes internal propagation and existing receiver integration coverage exercises these flags.

## Disruptive User Impact

None. Configured feature flags now consistently reach OTel Beat receivers.

## How to test this PR locally

### Run the tests

```shell
go test ./pkg/features
go test ./internal/pkg/otel/translate
go vet ./pkg/features ./internal/pkg/otel/translate
```

### Manual test

#### 1. Build and unpack a development Agent package

From the repository root:

```shell
mage dev:package
cd build/distributions
tar -xf elastic-agent-9.6.0-SNAPSHOT-linux-x86_64.tar.gz 
cd elastic-agent-9.6.0-SNAPSHOT-linux-x86_64
```

#### 2. Create a test log and `elastic-agent.yml`

The policy deliberately configures a legacy `log` input, forces it to run as a Beat receiver, and enables `agent.features.log_input_run_as_filestream`.

```shell
printf 'manual feature propagation test line %04d\n' {1..200} > /tmp/elastic-agent-feature-test.log
```

<details><summary>elastic-agent.yml</summary>
<p>

```yaml
agent:
  logging:
    level: debug
    to_stderr: true
  features:
    log_input_run_as_filestream:
      enabled: true
  internal:
    runtime:
      default: process
      filebeat:
        log: otel

outputs:
  default:
    type: elasticsearch
    hosts: [http://127.0.0.1:9200]
    username: elastic
    password: changeme

inputs:
  - id: manual-log-receiver
    type: log
    use_output: default
    data_stream:
      namespace: default
    streams:
      - id: manual-log-receiver.generic
        data_stream:
          dataset: generic
        paths:
          - /tmp/elastic-agent-feature-test.log
        allow_deprecated_use: true

agent.grpc:
  port: 5050
```

</p>
</details>

#### 3. Start Elastic Agent in standalone mode

```shell
sudo ./elastic-agent run -e 2>&1 | tee /tmp/elastic-agent-feature-test-output.log
```

Connection errors for `127.0.0.1:9200` are expected when Elasticsearch is not running and do not affect this test.

#### 4. Verify that the `log` input started as Filestream

In another terminal:
```shell
grep "running as Filestream" /tmp/elastic-agent-feature-test-output.log | jq '[.log.source, .message]'
grep "Input 'filestream' starting" /tmp/elastic-agent-feature-test-output.log| jq '[.log.source, .message]'
```

The output should contain a Filebeat receiver log similar to:

```
[
  "log-default",
  "Log input (deprecated) running as Filestream input"
]
[
  "filestream-monitoring",
  "Input 'filestream' starting"
]
[
  "log-default",
  "Input 'filestream' starting"
]
```

The standalone policy still declares `type: log`; seeing `input.filestream` and `Input 'filestream' starting` confirms that `agent.features.log_input_run_as_filestream.enabled: true` reached the generated Beat receiver and was applied. Stop the Agent with Ctrl-C after the assertion succeeds.

## Related issues

- Closes #15437
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56c89ca6-d84b-4927-bb14-602af2dff821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56c89ca6-d84b-4927-bb14-602af2dff821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

